### PR TITLE
Bug Fix (keep spaces from being deleted in description)

### DIFF
--- a/helpers/SG_iCal_Parser.php
+++ b/helpers/SG_iCal_Parser.php
@@ -76,12 +76,12 @@ class SG_iCal_Parser {
 		$data = array();
 		$content = explode("\n", $content);
 		for( $i=0; $i < count($content); $i++) {
-			$line = rtrim($content[$i]);
+			$line = rtrim($content[$i], "\n\r\t\v\0");
 			while( isset($content[$i+1]) && strlen($content[$i+1]) > 0 && ($content[$i+1]{0} == ' ' || $content[$i+1]{0} == "\t" )) {
-				$line .= rtrim(substr($content[++$i],1));
+				$line .= rtrim(substr($content[++$i],1), "\n\r\t\v\0");
 			}
 			$data[] = $line;
-		}
+		}	
 		return $data;
 	}
 


### PR DESCRIPTION
Fix bug that deleted space in event description if they happened to occur at the end of a line.


Extended description:

In SG_iCal_Parser, there are the following lines:

	protected static function UnfoldLines($content) {
		$data = array();
		$content = explode("\n", $content);
		for( $i=0; $i < count($content); $i++) {
			$line = rtrim($content[$i]);
			while( isset($content[$i+1]) && strlen($content[$i+1]) > 0 && ($content[$i+1]{0} == ' ' || $content[$i+1]{0} == "\t" )) {
				$line .= rtrim(substr($content[++$i],1));
			}
			$data[] = $line;
		}
		return $data;
	}

I kept running into the following problem on the front end: unpredictably, in the event description, a space in the text would sometimes disappear. Looking at the .ics file, I figured out that the space would disappear when it occurred at the end of a line in the file.

Here’s how I fixed the issue:

Change 

$line = rtrim($content[$i]);

to 

$line = rtrim($content[$i], "\n\r\t\v\0”);

which removes trailing whitespace (new lines, tabs, etc), but not actual spaces, and do the same for this line: 

$line .= rtrim(substr($content[++$i],1));

which should be changed to:

$line .= rtrim(substr($content[++$i],1), "\n\r\t\v\0”);
